### PR TITLE
Provide means to query if the current context is that of a worker thread

### DIFF
--- a/includes/tacopie/network/io_service.hpp
+++ b/includes/tacopie/network/io_service.hpp
@@ -76,6 +76,15 @@ public:
   //!
   void set_nb_workers(std::size_t nb_threads);
 
+  //!
+  //! Query if this context is the same as one of the nb worker threads.
+  //!
+  //! This is useful to debug or detect when a Redis operation is being peformed
+  //! in the context of a callback from one of the nb worker threads as opposed to
+  //! an application context.
+  //!
+  bool is_nb_worker_context();
+
 public:
   //! callback handler typedef
   //! called on new socket event if register to io_service

--- a/includes/tacopie/utils/thread_pool.hpp
+++ b/includes/tacopie/utils/thread_pool.hpp
@@ -106,6 +106,14 @@ public:
   //!
   void set_nb_threads(std::size_t nb_threads);
 
+  //!
+  //! Query if given thread id belongs to one of the worker threads.
+  //!
+  //! This can be useful to debug and detect when Redis commands are being 
+  //! sent in the context of the worker thread instead of application context.
+  //!
+  bool is_worker_thread_id(const std::thread::id& id);
+
 private:
   //!
   //! worker main loop

--- a/sources/network/io_service.cpp
+++ b/sources/network/io_service.cpp
@@ -92,6 +92,14 @@ io_service::set_nb_workers(std::size_t nb_threads) {
   m_callback_workers.set_nb_threads(nb_threads);
 }
 
+//!
+//! Is this worker thread context
+//!
+bool
+io_service::is_nb_worker_context() {
+  return(m_callback_workers.is_worker_thread_id(std::this_thread::get_id()));
+}
+
 
 //!
 //! poll worker function


### PR DESCRIPTION
Adds the ability to query if the current thread is one of the worker threads inn tacopie.  Applications should avoid issuing client or subscribe Redis commands in the thread context of the tacopie netowkr worker threads (e.g. callbacks).  It is sometimes not obvious that the current context is from a cpp_redis callback or one of the network worker threasd.  This change provides the means to test or query if the current context is that of a netowrk worker thread.  Generally this is useful for debugging or testing purposes.